### PR TITLE
CI/CD Process for Re-Ignited-Phone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,57 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Triggers the workflow on push or pull request.
 on:
   push:
-    branches: [ master ]
+    paths-ignore:
+    - 'sql/**'
+    - '**.md'
   pull_request:
-    branches: [ master ]
+    paths-ignore:
+    - 'sql/**'
+    - '**.md'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# Build Workflow
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-      - run: cd ./src_htmlPhone && npm install
-      - run: cd ./src_htmlPhone && npm run build
+      # Prep phase
+      - run: mkdir -p resources/gcphone/html/static esx1-1 esx1-2
+      
+      # Build source
+      - run: cd src_htmlPhone && npm install && npm run build
+      - run: mkdir -p resources/gcphone/html/static
+
+      # Copy static files to final location
+      - run: cp -R src_htmlPhone/static/ resources/gcphone/html/
+      - run: cp src_htmlPhone/index.html resources/gcphone/html/index.html
+      
+      # Create a base resource for each ESX version
+      - run: cp -a resources/. esx-1-1/
+      - run: cp -a resources/. esx-1-2/
+      
+      # Configure server.lua for each ESX Version
+      - run: mv esx-1-1/server\ 1-1/server.lua esx-1-1/gcphone/server/server.lua
+      - run: mv esx-1-2/server\ 1-2/server.lua esx-1-2/gcphone/server/server.lua
+      
+      # Cleanup
+      - run: rm -r esx-1-1/server\ 1-1/ esx-1-1/server\ 1-2/
+      - run: rm -r esx-1-2/server\ 1-1/ esx-1-2/server\ 1-2/
+      
+      # Enable ESX 1.2 in gcphone/config.lua for ESX 1.2 resource
+      - run: sed 's/Config.newESX = false/Config.newESX = true/g' esx-1-2/gcphone/config.lua
+      
+      # Upload Artifacts for ESX 1.1 and ESX 1.2
+      - uses: actions/upload-artifact@master
+        with:
+          name: resources-esx-1-1
+          path: esx-1-1
+      - uses: actions/upload-artifact@master
+        with:
+          name: resources-esx-1-2
+          path: esx-1-2

--- a/Instructions.md
+++ b/Instructions.md
@@ -1,28 +1,14 @@
-# Installation (ESX 1.1)
-> 1. Navigate to Re-Ignited-Phone-master > resources
-> 2. Copy/Drag the gcphone Folder into your server resources folder. (You no longer need esx_addons_gcphone as it was merged with the phone)
+# Installation 
+> 1. Download the release for your ESX version (ESX 1.1 & ESX 1.2) from [Releases](https://github.com/Re-Ignited-Development/Re-Ignited-Phone/releases)
+> 2. Copy/Drag the **gcphone** folder into your server resources folder. (You no longer need esx_addons_gcphone as it was merged with the phone)
 > 3. Import the following SQL's: `base.sql` and `twitter.sql` **(This is the same as the other versions.)** (Locales available in the sql folder.)
-> 4. Add the following to server.cfg **AFTER es_extended** & **BEFORE any jobs**. (Such as esx_ambulancejob, esx_policejob etc...)
+> 4. Add the following to your server.cfg **AFTER es_extended** & **BEFORE any jobs**. (Such as esx_ambulancejob, esx_policejob etc...)
 
 ``` 
 ensure gcphone
 ```
 
 > 5. Start your server.
-
-## Installation (ESX 1.2 AKA V1 Final)
-> 1. Navigate to Re-Ignited-Phone-master > resources
-> 2. Copy/Drag the gcphone Folder into your server resources folder. (You no longer need esx_addons_gcphone as it was merged with the phone)
-> 3. Import the following SQL's: `base.sql` and `twitter.sql` **(This is the same as the other versions.)**
-> 4. Add the following to server.cfg AFTER es_extended & BEFORE jobs.
-
-``` 
-ensure gcphone
-```
-
-> 5. Navigate to `gcphone > config.lua` line `21`.
-> 6. Change `Config.newESX = false` to `Config.newESX = true`.
-> 7. Start your server.
 
 # Notes
 -**No changes to fxmanifest is needed when adding new images to the resource due to Globbing. Can read more about this [here](https://docs.fivem.net/docs/scripting-reference/resource-manifest/resource-manifest/#globbing "FIveM Globbing Information")**.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![CI](https://github.com/Re-Ignited-Development/Re-Ignited-Phone/workflows/CI/badge.svg?branch=master)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/re-ignited-development/re-ignited-phone?style=flat-square)
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/reignited)
-[![Discord](https://img.shields.io/discord/463752820026376202.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/9uRJv5v)
+[![Discord](https://img.shields.io/discord/308323056592486420.svg?label=Support&logo=discord)](https://discord.gg/9uRJv5v)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://opensource.org/licenses/gpl-3.0.html)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## ReDesign & Functionality
 
-![CI](https://github.com/gabrielcalderon/Re-Ignited-Phone/workflows/CI/badge.svg)
+![CI](https://github.com/gabrielcalderon/Re-Ignited-Phone/workflows/CI/badge.svg?branch=master))
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/re-ignited-development/re-ignited-phone?style=flat-square)
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/reignited)
 [![Discord](https://img.shields.io/discord/463752820026376202.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/9uRJv5v)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,19 @@
 
-# ReDesign & Functionality
+## ReDesign & Functionality
 
-  
+![CI](https://github.com/gabrielcalderon/Re-Ignited-Phone/workflows/CI/badge.svg)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/re-ignited-development/re-ignited-phone?style=flat-square)
+[![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/reignited)
+[![Discord](https://img.shields.io/discord/463752820026376202.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/9uRJv5v)
+[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://opensource.org/licenses/gpl-3.0.html)
 
-# UPDATE: If you're on ESX 1.1 or older, please use the server.lua in resources/server 1-1 folder. If you're on ESX 1.2, please use the server.lua in resources/server 1-2 folder!!!
-
-  
-
-## Full Support on the Re-Ignited ESX Support Discord @ [This Link](https://discord.gg/9uRJv5v) or https://discord.gg/9uRJv5v
-
-  
-
-### [Downloads page](https://github.com/btngaming/Re-Ignited-Phone/releases)
-
-  
-
-### [Patreon Per Request](https://www.patreon.com/reignited)
-
-  
 
 <h2  align="center">GCPhone Redesign for FiveM</h2>
 
-  
+## Latest Release
+
+* ESX 1.1 & ESX 1.2 Download from [Releases](https://github.com/Re-Ignited-Development/Re-Ignited-Phone/releases)
+* Install instructions [Here](https://github.com/Re-Ignited-Development/Re-Ignited-Phone/blob/master/Instructions.md)
 
 ## Features
 
@@ -56,11 +48,7 @@
 - Easy installation instructions. Created for us by @Rocky_southpaw#7777
 
   
-  
-
 ## Configuration
-
-  
 
 - You can modify the sounds in \ html \ static \ sound
 
@@ -76,21 +64,15 @@
 
 - See Images at bottom of page for examples.
 
-  
-  
-
 ## About esx_addons_gcphone
 
 ESX Addons GCPhone has been merged INTO the gcphone files for ease of use. **You are no longer required to add `ensure esx_addons_gcphone` to your server.cfg.**
 
-  
-
 Please put `ensure gcphone` before jobs.
 
-Exemple :
+Example :
 
 ```
-
 ensure mysql-async
 
 ensure essentialmode (For esx 1.1)
@@ -100,58 +82,13 @@ ensure es_extended
 ensure gcphone
 ensure screenshot-basic
 
-  
-
 ensure esx_policejob
 ensure esx_ambulancejob
 ensure esx_job3
-ensure esx_job4
-
 ```
-
-  
-
-## License
-
-[GNU v3](https://opensource.org/licenses/gpl-3.0.html)
 
 ### [Credits](https://github.com/BTNGaming/Re-Ignited-Phone/blob/master/AUTHORS)
 
-  
-  
+## Screenshots
 
-![Image of gcphone1](https://i.imgur.com/5eRB79a.png)
-
-![Image of gcphone2](https://i.imgur.com/CakgFn3.png)
-
-![Image of gcphone3](https://i.imgur.com/QtthwvP.png)
-
-![Image of gcphone4](https://i.imgur.com/tRhczfK.jpg)
-
-![Image of gcphone5](https://i.imgur.com/YILmCWo.jpg)
-
-![Image of gcphone6](https://i.imgur.com/1MUATnT.png)
-
-![Image of gcphone7](https://i.imgur.com/Se2zwwK.png)
-
-![Image of gcphone8](https://i.imgur.com/aRUZTmP.png)
-
-![Image of gcphone9](https://i.imgur.com/iWbZ0lX.png)
-
-![Image of gcphone10](https://i.imgur.com/g5xdnXG.png)
-
-![Image of gcphone11](https://i.imgur.com/Giqet8j.png)
-
-![Image of gcphone12](https://i.imgur.com/FpzA6Mg.png)
-
-![Image of gcphone13](https://i.imgur.com/8dZTX5d.png)
-
-![Image of gcphone14](https://i.imgur.com/YDkWvx5.png)
-
-![Image of gcphone15](https://i.imgur.com/rS17u60.png)
-
-![Image of gcphone16](https://i.imgur.com/7GkMKaA.png)
-
-![Image of gcphone17](https://i.imgur.com/W3Cs4WM.png)
-
-![Image of gcphone18](https://i.imgur.com/WSUkwmE.png)
+<img src="https://i.imgur.com/5eRB79a.png" width="45%"></img> <img src="https://i.imgur.com/CakgFn3.png" width="45%"></img> <img src="https://i.imgur.com/tRhczfK.jpg" width="45%"></img> <img src="https://i.imgur.com/YILmCWo.jpg" width="45%"></img> <img src="https://i.imgur.com/1MUATnT.png" width="45%"></img> <img src="https://i.imgur.com/QtthwvP.png" width="45%"></img> <img src="https://i.imgur.com/Se2zwwK.png" width="45%"></img> <img src="https://i.imgur.com/aRUZTmP.png" width="45%"></img> <img src="https://i.imgur.com/iWbZ0lX.png" width="45%"></img> <img src="https://i.imgur.com/g5xdnXG.png" width="45%"></img> <img src="https://i.imgur.com/Giqet8j.png" width="45%"></img> <img src="https://i.imgur.com/FpzA6Mg.png" width="45%"></img> <img src="https://i.imgur.com/8dZTX5d.png" width="45%"></img> <img src="https://i.imgur.com/YDkWvx5.png" width="45%"></img> <img src="https://i.imgur.com/7GkMKaA.png" width="45%"></img> <img src="https://i.imgur.com/rS17u60.png" width="45%"></img> <img src="https://i.imgur.com/W3Cs4WM.png" width="45%"></img> <img src="https://i.imgur.com/WSUkwmE.png" width="45%"></img>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## ReDesign & Functionality
 
-![CI](https://github.com/gabrielcalderon/Re-Ignited-Phone/workflows/CI/badge.svg?branch=master))
+![CI](https://github.com/gabrielcalderon/Re-Ignited-Phone/workflows/CI/badge.svg?branch=master)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/re-ignited-development/re-ignited-phone?style=flat-square)
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/reignited)
 [![Discord](https://img.shields.io/discord/463752820026376202.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/9uRJv5v)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## ReDesign & Functionality
 
-![CI](https://github.com/gabrielcalderon/Re-Ignited-Phone/workflows/CI/badge.svg?branch=master)
+![CI](https://github.com/Re-Ignited-Development/Re-Ignited-Phone/workflows/CI/badge.svg?branch=master)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/re-ignited-development/re-ignited-phone?style=flat-square)
 [![Patreon](https://img.shields.io/badge/patreon-donate-orange.svg)](https://www.patreon.com/reignited)
 [![Discord](https://img.shields.io/discord/463752820026376202.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/9uRJv5v)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ensure esx_ambulancejob
 ensure esx_job3
 ```
 
-### [Credits](https://github.com/BTNGaming/Re-Ignited-Phone/blob/master/AUTHORS)
+### [Credits](https://github.com/Re-Ignited-Development/Re-Ignited-Phone/blob/master/AUTHORS)
 
 ## Screenshots
 


### PR DESCRIPTION
* Added support for building artifacts for both ESX 1.1 and 1.2 using Github Actions.
* Updated Node CI stage to use *actions/setup-node@v2-beta* which has built-in caching for faster builds.
* Completely refactored the Readme file.
* Added badges for CI, Release Tag, Patreon, Discord, License
* Update Instructions file.
* The CI process will **NOT** run if changes to SQL and .MD files are made.
* Simplifies the process of creating a new tag, Just download the latest Resources from the latest Master build and create a tag with those.

You can see how the new readme looks [Here](https://github.com/gabrielcalderon/Re-Ignited-Phone/)

Note:

* With the new CI process the users are no longer required to move server.lua files and modify their config when using ESX 1.2. For every Push/Pull Request Github will build and upload artifacts for each ESX version.

* Basically the CI will take care of the manual file moving and setup required for each ESX version.

* The CI process will create two artifacts: **resources-esx-1-1** and **resources-esx-1-2**