### PR TITLE
(Fix:) Fixed when sending position it returns as `%pos%`

### DIFF
--- a/resources/gcphone/client/client.lua
+++ b/resources/gcphone/client/client.lua
@@ -646,6 +646,8 @@ RegisterNUICallback('getMessages', function(data, cb)
 end)
 RegisterNUICallback('sendMessage', function(data, cb)
   if data.message == '%pos%' then
+    local myPos = GetEntityCoords(PlayerPedId())
+    data.message = 'GPS: ' .. myPos.x .. ', ' .. myPos.y
     data.gpsData = GetEntityCoords(PlayerPedId())
   end
   TriggerServerEvent('gcPhone:sendMessage', data.phoneNumber, data.message, data.gpsData)


### PR DESCRIPTION
Closes: https://github.com/Re-Ignited-Development/Re-Ignited-Phone/issues/30 / [Trello Issue]( https://trello.com/c/Dnp8MmPV/70-when-sending-gps-coordinates-to-any-job-the-cords-are-returned-to-as-pos)

This does NOT close https://github.com/Re-Ignited-Development/Re-Ignited-Phone/issues/39. We're still looking into this one.