### PR TITLE
Fixes weapon in hand + phone.

### DIFF
--- a/resources/gcphone/client/animation.lua
+++ b/resources/gcphone/client/animation.lua
@@ -60,10 +60,16 @@ function newPhoneProp()
 	end
 	phoneProp = CreateObject(phoneModel, 1.0, 1.0, 1.0, 1, 1, 0)
 	local bone = GetPedBoneIndex(myPedId, 28422)
-	AttachEntityToEntity(phoneProp, myPedId, bone, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, 1, 0, 0, 2, 1)
+	local isUnarmed = GetCurrentPedWeapon(myPedId, 0xA2719263)
+	if not isUnarmed then
+		AttachEntityToEntity(phoneProp, myPedId, bone, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, 1, 0, 0, 2, 1)
+	else
+		SetCurrentPedWeapon(myPedId, 0xA2719263, true)
+		AttachEntityToEntity(phoneProp, myPedId, bone, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, 1, 0, 0, 2, 1)
+	end
 end
 
-function deletePhone ()
+function deletePhone()
 	if phoneProp ~= 0 then
 		Citizen.InvokeNative(0xAE3CBE5BF394C9C9 , Citizen.PointerValueIntInitialized(phoneProp))
 		phoneProp = 0


### PR DESCRIPTION
if the player has a weapon out that then it simply removes it before creating the prop. 

https://trello.com/c/zO2hpImV/68-need-to-remove-weapon-from-hand-when-you-open-your-phone-so-people-dont-get-weird-animations

