### PR TITLE
Fix twitter replies not @'ing the original author

### DIFF
--- a/src_htmlPhone/src/components/twitter/TwitterView.vue
+++ b/src_htmlPhone/src/components/twitter/TwitterView.vue
@@ -116,12 +116,12 @@ export default {
         this.ignoreControls = true
         const rep = await Modal.CreateTextModal({
           title: 'Répondre',
-          text: `@${authorName} `
+          text: ``
         })
         if (rep !== undefined && rep.text !== undefined) {
           const message = rep.text.trim()
           if (message.length !== 0) {
-            this.twitterPostTweet({ message })
+            this.twitterPostTweet({ message: '@' + authorName + ' ' + message })
           }
         }
       } catch (e) {


### PR DESCRIPTION
Its not the prettiest way to do it but it definitely works, the only downside to this is the modal when using mouse control no longer has @authorName.. mybad for this not being posted earlier, apparently by default github creates PRs on my fork when I do it -_-