### PR TITLE
Fixed right click in notes and tchat

### DIFF
--- a/src_htmlPhone/src/components/Notes/NotesChannel.vue
+++ b/src_htmlPhone/src/components/Notes/NotesChannel.vue
@@ -1,7 +1,7 @@
 <template>
   <div style="width: 100%; height: 742px; color: white" class="phone_app">
     <PhoneTitle :title="IntlString('APP_NOTES')" backgroundColor="#f8d344" color="white" @back="onBack" />
-    <div  style="backgroundColor: white;" class="elements" @contextmenu.prevent="addChannelOption">
+    <div  style="backgroundColor: white;" class="elements" @contextmenu.prevent="onEnter">
         <div  
           >
             <div v-for='(elem, key) in notesChannels' 
@@ -80,18 +80,25 @@ export default {
     },
     async onEnter () {
       if (this.ignoreControls === true) return
+      this.ignoreControls = true
+      let choix = [
+        {id: 1, title: this.IntlString('APP_DARKTCHAT_NEW_NOTE'), icons: 'fa-plus', color: 'dodgerblue'},
+        {id: 2, title: this.IntlString('APP_DARKTCHAT_DELETE_NOTE'), icons: 'fa-minus', color: 'tomato'},
+        {id: 3, title: this.IntlString('APP_DARKTCHAT_CANCEL'), icons: 'fa-undo'}
+      ]
       if (this.notesChannels.length === 0) {
-        this.ignoreControls = true
-        let choix = [
-          {id: 1, title: this.IntlString('APP_DARKTCHAT_NEW_CHANNEL'), icons: 'fa-plus', color: 'green'},
-          {id: 3, title: this.IntlString('APP_DARKTCHAT_CANCEL'), icons: 'fa-undo'}
-        ]
-        const rep = await Modal.CreateModal({ choix })
-        this.ignoreControls = false
-        if (rep.id === 1) {
+        choix.splice(1, 1)
+      }
+      const rep = await Modal.CreateModal({ choix })
+      this.ignoreControls = false
+      switch (rep.id) {
+        case 1:
           this.addChannelOption()
-        }
-      } else {
+          break
+        case 2:
+          this.removeChannelOption()
+          break
+        case 3 :
       }
     },
     showChannel (channel) {
@@ -103,7 +110,7 @@ export default {
     },
     async addChannelOption () {
       try {
-        const rep = await Modal.CreateTextModal({limit: 280, title: this.IntlString('APP_DARKTCHAT_NEW_CHANNEL')})
+        const rep = await Modal.CreateTextModal({limit: 280, title: this.IntlString('APP_DARKTCHAT_NEW_NOTE')})
         let channel = (rep || {}).text || ' '
         channel
         if (channel.length > 0) {

--- a/src_htmlPhone/src/components/Tchat/TchatChannel.vue
+++ b/src_htmlPhone/src/components/Tchat/TchatChannel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="phone_app">
     <PhoneTitle :title="IntlString('APP_DARKTCHAT_TITLE')" backgroundColor="#2b2a2a" @back="onBack" /> <!-- HEADER -->
-    <div class="elements" @contextmenu.prevent="addChannelOption">
+    <div class="elements" @contextmenu.prevent="onEnter">
         <div class="element" v-for='(elem, key) in tchatChannels' 
           v-bind:key="elem.channel"
           v-bind:class="{ select: key === currentSelect}"
@@ -79,20 +79,25 @@ export default {
     },
     async onEnter () {
       if (this.ignoreControls === true) return
+      this.ignoreControls = true
+      let choix = [
+        {id: 1, title: this.IntlString('APP_DARKTCHAT_NEW_CHANNEL'), icons: 'fa-plus', color: 'green'}, /** New Channel Option Color */
+        {id: 2, title: this.IntlString('APP_DARKTCHAT_DELETE_CHANNEL'), icons: 'fa-minus', color: 'red'}, /** DeleteChannel Option Color */
+        {id: 3, title: this.IntlString('APP_DARKTCHAT_CANCEL'), icons: 'fa-undo'}
+      ]
       if (this.tchatChannels.length === 0) {
-        this.ignoreControls = true
-        let choix = [
-          {id: 1, title: this.IntlString('APP_DARKTCHAT_NEW_CHANNEL'), icons: 'fa-plus', color: 'green'}, /** New Channel Option Color */
-          {id: 3, title: this.IntlString('APP_DARKTCHAT_CANCEL'), icons: 'fa-undo'}
-        ]
-        const rep = await Modal.CreateModal({ choix })
-        this.ignoreControls = false
-        if (rep.id === 1) {
+        choix.splice(1, 1)
+      }
+      const rep = await Modal.CreateModal({ choix })
+      this.ignoreControls = false
+      switch (rep.id) {
+        case 1:
           this.addChannelOption()
-        }
-      } else {
-        const channel = this.tchatChannels[this.currentSelect].channel
-        this.showChannel(channel)
+          break
+        case 2:
+          this.removeChannelOption()
+          break
+        case 3 :
       }
     },
     showChannel (channel) {


### PR DESCRIPTION
Both notes and chat have correct menus again, notes/channels can be deleted via mouse.
Right click in either one was set to call the "newChannel/newNote" event instead of the choix with the options.
Also fixed a small copy & paste mistake where creating new notes said "Create new channel" 😁