### PR TITLE
Modifications to Twitter Discord logging

### DIFF
--- a/resources/gcphone/config.lua
+++ b/resources/gcphone/config.lua
@@ -35,3 +35,4 @@ Config.NoPhoneWarning = false -- If true, the player is warned when trying to op
 
 -- Optional Discord Logging
 Config.UseTwitterLogging = false -- Set the Discord webhook in twitter.lua line 284
+Config.TwitterDiscordWebhook = ''

--- a/resources/gcphone/config.lua
+++ b/resources/gcphone/config.lua
@@ -34,5 +34,5 @@ Config.ItemRequired = false -- If true, must have the item "phone" to use it.
 Config.NoPhoneWarning = false -- If true, the player is warned when trying to open the phone that they need a phone. To edit this message go to the locales for your language.
 
 -- Optional Discord Logging
-Config.UseTwitterLogging = false -- Set the Discord webhook in twitter.lua line 284
-Config.TwitterDiscordWebhook = ''
+Config.UseTwitterLogging = false -- Enables Twitter logging to a Discord channel - true = yes, false = no
+Config.TwitterDiscordWebhook = '' -- Set the Discord channel webhook for your Twitter logging channel here

--- a/resources/gcphone/server/twitter.lua
+++ b/resources/gcphone/server/twitter.lua
@@ -281,7 +281,7 @@ end)
 -- DIscord Webhook must be enabled in the config.lua
 AddEventHandler('gcPhone:twitter_newTweets', function (tweet)
   -- print(json.encode(tweet))
-  local discord_webhook = 'https://discord.com/api/webhooks/' -- Set Discord Webhook. See https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
+  local discord_webhook = Config.TwitterDiscordWebhook
   if discord_webhook == '' then
     return
   end


### PR DESCRIPTION
This pull request contains updated code to make configuration of a Discord webhook for Twitter logging easier, by adding Config.TwitterDiscordWebhook to config.lua and adding the variable to resources/gcphone/server/twitter.lua on line 284.